### PR TITLE
Support Kinesis AT_TIMESTAMP definition

### DIFF
--- a/lib/plugins/aws/package/compile/events/stream/index.js
+++ b/lib/plugins/aws/package/compile/events/stream/index.js
@@ -44,6 +44,7 @@ class AwsCompileStreamEvents {
             let BatchSize = 10;
             let StartingPosition = 'TRIM_HORIZON';
             let Enabled = 'True';
+            let Timestamp = null;
 
             // TODO validate arn syntax
             if (typeof event.stream === 'object') {
@@ -87,6 +88,7 @@ class AwsCompileStreamEvents {
                 || BatchSize;
               StartingPosition = event.stream.startingPosition
                 || StartingPosition;
+              Timestamp = event.stream.timestamp || Timestamp;
               if (typeof event.stream.enabled !== 'undefined') {
                 Enabled = event.stream.enabled ? 'True' : 'False';
               }
@@ -154,6 +156,7 @@ class AwsCompileStreamEvents {
                     ]
                   },
                   "StartingPosition": "${StartingPosition}",
+                  ${Timestamp ? `"Timestamp": ${Timestamp},` : ''}
                   "Enabled": "${Enabled}"
                 }
               }


### PR DESCRIPTION
Support Kinesis AT_TIMESTAMP definition by supporting timestamp fields in event declaration

Closes #3648
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

This enables Timestamp for kinesis event fields, such that one can create the event source mapping for timestamp: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateEventSourceMapping.html

## How did you implement it:

Added this field to the streamTemplate if it is present in the event declaration.

## How can we verify it:

Add `timestamp` to a kinesis event declaration, and verify in the cloudformation JSON.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
